### PR TITLE
Expand links in Twitter posts (+ some refactoring)

### DIFF
--- a/twitterservice.py
+++ b/twitterservice.py
@@ -25,113 +25,107 @@ following = {x[1] for x in users_list}
 # Tweet stream
 class MyStreamListener(StreamListener):
 
-    try:
-        def on_status(self, status):
+    def on_status(self, status):
 
-            #print(status.text)
-            #print(json.dumps(status._json))
+        #print(status.text)
+        #print(json.dumps(status._json))
 
-            # Converts the data into usable JSON
-            data = status._json
+        # Converts the data into usable JSON
+        data = status._json
 
 
-            # Puts user attributes into this list if the tweeet is from somebody the bot is following
-            # If the tweet isn't from someone the bot is following, set to None
-            # For some reason the twitter API also tells you when someone deletes a tweet
-            # If you try to get the needed properties from a deleted tweet, it throws a KeyError
-            try:
-                user_of_tweet = next((x for x in users_list if x[1] == data['user']['id_str']), None)
+        # Puts user attributes into this list if the tweeet is from somebody the bot is following
+        # If the tweet isn't from someone the bot is following, set to None
+        # For some reason the twitter API also tells you when someone deletes a tweet
+        # If you try to get the needed properties from a deleted tweet, it throws a KeyError
+        try:
+            user_of_tweet = next((x for x in users_list if x[1] == data['user']['id_str']), None)
 
-            except KeyError as e:
-                user_of_tweet = None
+        except KeyError as e:
+            user_of_tweet = None
 
-            # Sends the tweet to the database
-            def send_tweet_to_db(tweet_data, start_time):
+        # Sends the tweet to the database
+        def send_tweet_to_db(tweet_data, start_time):
 
-                # Gets the full tweet text if it's concatenated by Twitter
-                if "extended_tweet" in tweet_data:
-                    text = html.unescape(tweet_data['extended_tweet']['full_text'])
+            # Gets the full tweet text if it's concatenated by Twitter
+            if "extended_tweet" in tweet_data:
+                text = html.unescape(tweet_data['extended_tweet']['full_text'])
 
-                # Gets the full retweet text if it's concatenated by Twitter
-                elif "retweeted_status" in tweet_data and "extended_tweet" in tweet_data['retweeted_status']:
-                    rt_data = tweet_data['retweeted_status']
-                    text = f"RT @{rt_data['user']['screen_name']}: {html.unescape(rt_data['extended_tweet']['full_text'])}"
+            # Gets the full retweet text if it's concatenated by Twitter
+            elif "retweeted_status" in tweet_data and "extended_tweet" in tweet_data['retweeted_status']:
+                rt_data = tweet_data['retweeted_status']
+                text = f"RT @{rt_data['user']['screen_name']}: {html.unescape(rt_data['extended_tweet']['full_text'])}"
 
-                # Not an extended tweet
-                else:
-                    text = html.unescape(tweet_data['text'])
-                
-                # Logs raw JSON    
-                #logger.info(json.dumps(data))
+            # Not an extended tweet
+            else:
+                text = html.unescape(tweet_data['text'])
 
-                # Checks if the tweet is a parent to a reply, which won't have an ID
-                if tweet_data['id_str'] is not None:
-                    tweet_url = make_url_from_tweet(tweet_data['user']['screen_name'], tweet_data['id_str'])
-                else:
-                    tweet_url = ''
+            # Logs raw JSON
+            #logger.info(json.dumps(data))
 
-                db.insert_message('Twitter', tweet_data['user']['screen_name'], text.replace("\n", " "), tweet_url, start_time)
+            # Checks if the tweet is a parent to a reply, which won't have an ID
+            if tweet_data['id_str'] is not None:
+                tweet_url = make_url_from_tweet(tweet_data['user']['screen_name'], tweet_data['id_str'])
+            else:
+                tweet_url = ''
 
-            # Is the tweet from somebody the bot cares about?
-            if user_of_tweet is not None:
+            db.insert_message('Twitter', tweet_data['user']['screen_name'], text.replace("\n", " "), tweet_url, start_time)
 
-                start_time = time.time()
+        # Is the tweet from somebody the bot cares about?
+        if user_of_tweet is not None:
 
-                # Is it a retweet?             Is the retweet flag of the user set to 1?
-                if "retweeted_status" in data and user_of_tweet[2] == 1:
-                    rt_data = data['retweeted_status']
+            start_time = time.time()
 
-                    # Has the retweeted status already been posted?
-                    # No, post it
-                    if not has_tweet_been_posted(rt_data['user']['screen_name'], rt_data['id_str']):
-                        send_tweet_to_db(data, start_time)
+            # Is it a retweet?             Is the retweet flag of the user set to 1?
+            if "retweeted_status" in data and user_of_tweet[2] == 1:
+                rt_data = data['retweeted_status']
 
-                    # Yes, don't post it
-                    else:
-                       logger.info("Retweet has already been posted")
-
-                # Is a reply?                  Is the reply flag of the user set to 1?
-                elif data['in_reply_to_status_id'] is not None and user_of_tweet[3] == 1:
-                    
-                    reply_data = get_status(data['in_reply_to_status_id'])
-
-                    # Has the parent tweet to the reply been posted already?
-                    # No, send it as context
-                    if not has_tweet_been_posted(reply_data['user']['screen_name'], reply_data['id_str']):
-
-                        # Avoid IRC double pings
-                        usernames_to_modify = ['@elonmusk', '@SpaceX']
-                        
-                        for username in usernames_to_modify:
-                            ZWJ = "‍"
-                            
-                            # Inserts a Zero Width Joiner
-                            username_zwj = username[:2] + ZWJ + username[2:]
-                            reply_data['full_text'] = reply_data['full_text'].replace(username, username_zwj)
-
-                        reply_data['text'] = reply_data['full_text']
-
-                        # Don't send the ID of the reply tweet
-                        reply_data['id_str'] = None
-
-                        send_tweet_to_db(reply_data, start_time)
-                        time.sleep(0.5)
-                        send_tweet_to_db(data, start_time)
-
-                    # Yes, don't send it again
-                    else:
-                        send_tweet_to_db(data, start_time)
-                        logger.info("Parent tweet already posted")
-
-                # If it's a normal tweet
-                elif "retweeted_status" not in data and data["in_reply_to_status_id"] is None:
+                # Has the retweeted status already been posted?
+                # No, post it
+                if not has_tweet_been_posted(rt_data['user']['screen_name'], rt_data['id_str']):
                     send_tweet_to_db(data, start_time)
 
+                # Yes, don't post it
+                else:
+                    logger.info("Retweet has already been posted")
 
-    except error as e:
-        logger.error(str(e))
-        logger.error("-----FOUND ERROR-----")
-        
+            # Is a reply?                  Is the reply flag of the user set to 1?
+            elif data['in_reply_to_status_id'] is not None and user_of_tweet[3] == 1:
+
+                reply_data = get_status(data['in_reply_to_status_id'])
+
+                # Has the parent tweet to the reply been posted already?
+                # No, send it as context
+                if not has_tweet_been_posted(reply_data['user']['screen_name'], reply_data['id_str']):
+
+                    # Avoid IRC double pings
+                    usernames_to_modify = ['@elonmusk', '@SpaceX']
+
+                    for username in usernames_to_modify:
+                        ZWJ = "‍"
+
+                        # Inserts a Zero Width Joiner
+                        username_zwj = username[:2] + ZWJ + username[2:]
+                        reply_data['full_text'] = reply_data['full_text'].replace(username, username_zwj)
+
+                    reply_data['text'] = reply_data['full_text']
+
+                    # Don't send the ID of the reply tweet
+                    reply_data['id_str'] = None
+
+                    send_tweet_to_db(reply_data, start_time)
+                    time.sleep(0.5)
+                    send_tweet_to_db(data, start_time)
+
+                # Yes, don't send it again
+                else:
+                    send_tweet_to_db(data, start_time)
+                    logger.info("Parent tweet already posted")
+
+            # If it's a normal tweet
+            elif "retweeted_status" not in data and data["in_reply_to_status_id"] is None:
+                send_tweet_to_db(data, start_time)
+
     # Trying to find out what's causing the random Twitter crashes
     def on_error(self, status):
         if status == 420:

--- a/twitterservice.py
+++ b/twitterservice.py
@@ -44,33 +44,6 @@ class MyStreamListener(StreamListener):
         except KeyError as e:
             user_of_tweet = None
 
-        # Sends the tweet to the database
-        def send_tweet_to_db(tweet_data, start_time):
-
-            # Gets the full tweet text if it's concatenated by Twitter
-            if "extended_tweet" in tweet_data:
-                text = html.unescape(tweet_data['extended_tweet']['full_text'])
-
-            # Gets the full retweet text if it's concatenated by Twitter
-            elif "retweeted_status" in tweet_data and "extended_tweet" in tweet_data['retweeted_status']:
-                rt_data = tweet_data['retweeted_status']
-                text = f"RT @{rt_data['user']['screen_name']}: {html.unescape(rt_data['extended_tweet']['full_text'])}"
-
-            # Not an extended tweet
-            else:
-                text = html.unescape(tweet_data['text'])
-
-            # Logs raw JSON
-            #logger.info(json.dumps(data))
-
-            # Checks if the tweet is a parent to a reply, which won't have an ID
-            if tweet_data['id_str'] is not None:
-                tweet_url = make_url_from_tweet(tweet_data['user']['screen_name'], tweet_data['id_str'])
-            else:
-                tweet_url = ''
-
-            db.insert_message('Twitter', tweet_data['user']['screen_name'], text.replace("\n", " "), tweet_url, start_time)
-
         # Is the tweet from somebody the bot cares about?
         if user_of_tweet is not None:
 
@@ -179,3 +152,30 @@ def make_url_from_tweet(screen_name, id_str):
 
 def has_tweet_been_posted(screen_name, id_str):
     return db.get_tweet_posted(make_url_from_tweet(screen_name, id_str)) != []
+
+def send_tweet_to_db(tweet_data, start_time):
+    """Sends the tweet to the database"""
+
+    # Gets the full tweet text if it's concatenated by Twitter
+    if "extended_tweet" in tweet_data:
+        text = html.unescape(tweet_data['extended_tweet']['full_text'])
+
+    # Gets the full retweet text if it's concatenated by Twitter
+    elif "retweeted_status" in tweet_data and "extended_tweet" in tweet_data['retweeted_status']:
+        rt_data = tweet_data['retweeted_status']
+        text = f"RT @{rt_data['user']['screen_name']}: {html.unescape(rt_data['extended_tweet']['full_text'])}"
+
+    # Not an extended tweet
+    else:
+        text = html.unescape(tweet_data['text'])
+
+    # Logs raw JSON
+    #logger.info(json.dumps(data))
+
+    # Checks if the tweet is a parent to a reply, which won't have an ID
+    if tweet_data['id_str'] is not None:
+        tweet_url = make_url_from_tweet(tweet_data['user']['screen_name'], tweet_data['id_str'])
+    else:
+        tweet_url = ''
+
+    db.insert_message('Twitter', tweet_data['user']['screen_name'], text.replace("\n", " "), tweet_url, start_time)


### PR DESCRIPTION
First three commits are general cleanup to make things more readable.

Last commit adds expansion from `t.co` links to the original URLs,
 or in case of media to the URL of the actual file rather than
 Twitter's gallery page.

This avoids having to go through Twitter's website to see the content,
 which is very annoying on browsers with any privacy settings because
 of constant popups, "Not Available" errors and other obstructions.

- Remove bogus exception handler
- Move definition of `send_tweet_to_db` out of `on_status`.
- Early return if `user_of_tweet` is None
- Expand links in Twitter content
